### PR TITLE
gdbpmp.py: put the gdbpmp's dir in sys.path on import failure.

### DIFF
--- a/gdbpmp.py
+++ b/gdbpmp.py
@@ -3,7 +3,13 @@
 
 import sys
 import os
-import common
+
+try:
+    import common
+except ImportError:
+    sys.path.append(os.path.dirname(__file__))
+    import common
+
 import gdbtypes
 import subprocess
 import signal


### PR DESCRIPTION
GDB 7.11.1-0ubuntu1~16.5 was complaining that `common.py` can't be found. It turned out that the directory holding the file was absent in `sys.path` for code injected with the GDB's `source` command. This patch fixes that.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>