### PR TITLE
tracer: add new detach/attach trace option.

### DIFF
--- a/common.py
+++ b/common.py
@@ -19,6 +19,8 @@ def parse_args(args=None):
     parser.add_argument('-g', '--gdb_path', required=False, type=str, default='/usr/bin/gdb', help='Path to the GDB executable.')
     parser.add_argument('-t', '--threshold', required=False, type=float, default=0.1, help='Ignore results below the threshold when making the callgraph.')
     parser.add_argument('-v', '--invert', required=False, action='store_true', help='Print inverted callgraph.')
+    parser.add_argument('-d', '--detachattach', required=False, action='store_true', help='Use the detach/attach trace mode.  Slower, but more compatible.')
+
     if args:
         return parser.parse_args(args)
     else:


### PR DESCRIPTION
Some processes (seastar!) appear to muck around with signal handling in ways that prevent GDB from getting consistent results when sending SIGINT to pause the process after a set amount of time after continue.  To work around this, this PR adds an option to use a "detach, sleep, attach" method for tracing instead.  This is far slower, but so far appears to result in callgraphs more inline with expectations in these cases.  Further verification against other 3rd party tools is highly desirable.

Signed-off-by: Mark Nelson <mnelson@redhat.com>