### PR TITLE
gdbpmp: Improve readability for extremely deep callgraphs (seastar!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ a bit wonky.
 ```
 usage: gdbpmp.py [-h] (-i INPUT | -p PID) [-s SLEEP] [-n SAMPLES] [-m MATCH]
                  [-x EXCLUDE] [-o OUTPUT] [-g GDB_PATH] [-t THRESHOLD] [-v]
+                 [-d] [-w MAX_WIDTH] [-r]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -48,6 +49,11 @@ optional arguments:
                         Ignore results below the threshold when making the
                         callgraph.
   -v, --invert          Print inverted callgraph.
+  -d, --detachattach    Use the detach/attach trace mode. Slower, but more
+                        compatible.
+  -w MAX_WIDTH, --max_width MAX_WIDTH
+                        Set the display width (default is terminal width)
+  -r, --truncate        Truncate lines to the terminal width
 ```
 ### Example
 ```

--- a/common.py
+++ b/common.py
@@ -3,6 +3,7 @@
 
 import argparse
 import pickle
+import shutil
 from gdbtypes import GDBFunction, GDBThread
 
 def parse_args(args=None):
@@ -20,22 +21,24 @@ def parse_args(args=None):
     parser.add_argument('-t', '--threshold', required=False, type=float, default=0.1, help='Ignore results below the threshold when making the callgraph.')
     parser.add_argument('-v', '--invert', required=False, action='store_true', help='Print inverted callgraph.')
     parser.add_argument('-d', '--detachattach', required=False, action='store_true', help='Use the detach/attach trace mode.  Slower, but more compatible.')
+    parser.add_argument('-w', '--max_width', required=False, type=int, default=shutil.get_terminal_size().columns, help='Set the display width (default is terminal width)')
+    parser.add_argument('-r', '--truncate', required=False, action='store_true', help="Truncate lines to the terminal width")
 
     if args:
         return parser.parse_args(args)
     else:
         return parser.parse_args()
 
-def print_callgraph(threads, threshold):
+def print_callgraph(ctx, threads):
     print("");
     for thn, gdbth in sorted(threads.items()):
         samples = gdbth.function.get_samples(True)
         print("")
         print(("Thread: %s (%s) - %s samples " % (gdbth.num, gdbth.name, samples)))
         print("")
-        gdbth.function.print_percent("", samples, threshold, True)
+        gdbth.function.print_percent(ctx, "", samples, True)
 
-def print_inverted_callgraph(threads, threshold):
+def print_inverted_callgraph(ctx, threads):
     print("")
     for thn, gdbth in sorted(threads.items()):
         samples = gdbth.function.get_samples(True)
@@ -43,7 +46,7 @@ def print_inverted_callgraph(threads, threshold):
         print("")
         print(("Thread: %s (%s) - %s samples " % (igdbth.num, igdbth.name, samples)))
         print("")
-        igdbth.function.print_percent("", samples, threshold, False)
+        igdbth.function.print_percent(ctx, "", samples, False)
 
 def invert_thread(gdbth):
     inverted_func = GDBFunction(None, 2)

--- a/gdbpmp.py
+++ b/gdbpmp.py
@@ -20,9 +20,9 @@ def main():
     if ctx.input:
         threads = common.load_threads(ctx.input)
         if ctx.invert:
-            common.print_inverted_callgraph(threads, ctx.threshold)
+            common.print_inverted_callgraph(ctx, threads)
         else:
-            common.print_callgraph(threads, ctx.threshold)
+            common.print_callgraph(ctx, threads)
     elif ctx.pid:
         this_path = os.path.realpath(__file__)
         pargs = ' '.join(sys.argv[1:])
@@ -45,4 +45,5 @@ if __name__ == "__main__":
     except ImportError:
         main()
         sys.exit(0)
+    sys.setrecursionlimit(5000)
     tracer.ProfileCommand()


### PR DESCRIPTION
This makes it far easier to read extremely deep callgraphs generated by crimson or other programs using nested futures style frameworks.  It provides additional options for custom maximum display widths to override the default behavior and the ability to truncate lines when a more compact view is desired.

Signed-off-by: Mark Nelson <mnelson@redhat.com>